### PR TITLE
Add a check for ip presence in active clients

### DIFF
--- a/get_unifi_reservations.py
+++ b/get_unifi_reservations.py
@@ -41,7 +41,7 @@ def get_clients():
         # Add active clients with alias
         # Active client IP overrides the reserved one (the actual IP is what matters most)
         for c in get_active_clients(s):
-            if 'name' in c:
+            if 'name' in c and 'ip' in c:
                 clients[c['mac']] = {'name': c['name'], 'ip': c['ip']}
     
     # Return a list of clients filtered on dns-friendly names and sorted by IP


### PR DESCRIPTION
There is an edge case where some virtual interfaces will not be assigned an IP. In that instance, the script errors. Instead, we should ignore them because they will not originate traffic and are not routable.