### PR TITLE
Replace whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Clients with DNS-incompatible names will be skipped.
 | `UNIFI_SITE`            | UniFi "site" name                               | `default`            |
 | `FIXED_ONLY`            | Flag for only handling clients with reserved IP | `False`              |
 | `LOG_LEVEL `            | Set logging level (e.g DEBUG, INFO etc)         | `INFO`               |
+| `REPLACE_WHITESPACES `  | Flag to replace whitspace with "-" in dns name  | `False`              |
 
 * `docker-compose up`
 * UniFi clients with DNS-compatible aliases will be written to `/etc/dnsmasq.d/unifi.hosts`.

--- a/get_unifi_reservations.py
+++ b/get_unifi_reservations.py
@@ -11,6 +11,7 @@ password = os.environ.get('UNIFI_PASSWORD')
 site = os.environ.get('UNIFI_SITE', 'default')
 fixed_only = os.environ.get('FIXED_ONLY', False)
 log_level = os.environ.get("LOG_LEVEL", "INFO")
+replace_whitespaces = os.environ.get('REPLACE_WHITESPACES', False)
 
 
 def get_configured_clients(session):
@@ -48,6 +49,9 @@ def get_clients():
     
     friendly_clients = list()
     for client in clients.values():
+        if replace_whitespaces:
+            client['name'] = client['name'].replace(" ", "-")
+
         if re.search('^[a-zA-Z0-9-]+$', client['name']):
             friendly_clients.append(client)
         else:


### PR DESCRIPTION
Using the option will make aliases in Unifi that contain whitespaces to be updated to a valid entry for DNS.

i.e alias "foo bar" will be changed to "foo-bar" instead.